### PR TITLE
Autocomplete for package names

### DIFF
--- a/server.R
+++ b/server.R
@@ -13,26 +13,16 @@ library(lubridate)
 library(cranlogs)
 library(zoo)
 
-# if package not found, keep the same one up
-last <- NULL
-last_package <- ""
-
 shinyServer(function(input, output) {
   downloads <- reactive({
       end_date <- Sys.Date() - 1
       start_date <- end_date - input$num_weeks * 7 + 1
       
-      packages <- str_split(input$package, ",")[[1]]
+      packages <- input$package
       cran_downloads0 <- failwith(NULL, cran_downloads, quiet = TRUE)
-      ret <- cran_downloads0(package = packages,
-                            from = start_date,
-                            to = end_date)
-      if (is.null(ret)) {
-          return(last)
-      }
-      last <<- ret
-      last_package <<- input$package
-      ret
+      cran_downloads0(package = packages,
+                      from = start_date,
+                    to = end_date)
   })
     
   output$downloadsPlot <- renderPlot({

--- a/ui.R
+++ b/ui.R
@@ -5,7 +5,10 @@
 # http://shiny.rstudio.com
 #
 
-library(shiny)
+# get the list of all packages on CRAN
+library(httr)
+library(jsonlite)
+package_names = names(httr::content(httr::GET("http://crandb.r-pkg.org/-/desc")))
 
 shinyUI(fluidPage(
 
@@ -16,8 +19,12 @@ shinyUI(fluidPage(
   sidebarLayout(
     sidebarPanel(
       HTML("Enter an R package to see the # of downloads over time from the RStudio CRAN Mirror.",
-           "You can enter multiple packages separated by commas (e.g. 'shiny,ggplot2') to compare them"),
-      textInput("package", "Package:", "shiny"),
+           "You can enter multiple packages to compare them"),
+      selectInput("package", 
+                  label = "Packages:",
+                  selected = sample(package_names, 2), # initialize the graph with a random package
+                  choices = package_names,
+                  multiple = TRUE),      
       # submitButton("View Downloads"),
       sliderInput("num_weeks",
                   "Number of weeks:",

--- a/ui.R
+++ b/ui.R
@@ -5,6 +5,7 @@
 # http://shiny.rstudio.com
 #
 
+library(shiny)
 # get the list of all packages on CRAN
 library(httr)
 library(jsonlite)


### PR DESCRIPTION
Get a list of all packages on CRAN.  This allows us to:
1. autocomplete the package name input
2. Start the app with two random packages.
